### PR TITLE
ConnectorState object should have same ID as connector_id and weaviate's internal id

### DIFF
--- a/verbis/store/store.go
+++ b/verbis/store/store.go
@@ -733,7 +733,9 @@ func UpdateConnectorState(ctx context.Context, client *weaviate.Client, state *t
 			"numDocuments": state.NumDocuments,
 			"numChunks":    state.NumChunks,
 			"numErrors":    state.NumErrors,
-		}).Do(ctx)
+		}).
+		WithID(state.ConnectorID).
+		Do(ctx)
 		return err
 	}
 


### PR DESCRIPTION
Before
```
$ curl -s http://localhost:8088/v1/objects\?class\=ConnectorState | jq .
{
  "deprecations": [],
  "objects": [
    {
      "class": "ConnectorState",
      "creationTimeUnix": 1718340550624,
      "id": "05e83ec6-70b4-4d91-86ee-4f82859c85e3",
      "lastUpdateTimeUnix": 1718340647117,
      "properties": {
        "auth_valid": true,
        "connector_id": "ead3366c-3eb2-462a-9847-510de39f30f9",
        "lastSync": "2024-06-14T10:19:54.372573+05:30",
        "numChunks": 238,
        "numDocuments": 29,
        "numErrors": 0,
        "syncing": false,
        "type": "slack",
        "user": "sahil @ Verbis AI"
      },
      "vectorWeights": null
    }
  ],
  "totalResults": 1
}
```
After
```$ curl -s http://localhost:8088/v1/objects\?class\=ConnectorState | jq .
{
  "deprecations": [],
  "objects": [
    {
      "class": "ConnectorState",
      "creationTimeUnix": 1718343404742,
      "id": "46e5da05-c621-4cac-ad10-11b4b9e51bae",
      "lastUpdateTimeUnix": 1718343426884,
      "properties": {
        "auth_valid": true,
        "connector_id": "46e5da05-c621-4cac-ad10-11b4b9e51bae",
        "lastSync": "0001-01-01T00:00:00Z",
        "numChunks": 40,
        "numDocuments": 1,
        "numErrors": 0,
        "syncing": false,
        "type": "slack",
        "user": "sahil @ Verbis AI"
      },
      "vectorWeights": null
    },
    {
      "class": "ConnectorState",
      "creationTimeUnix": 1718343414660,
      "id": "ab437bb8-fef8-4b49-b1cf-7724d542c53e",
      "lastUpdateTimeUnix": 1718343429240,
      "properties": {
        "auth_valid": true,
        "connector_id": "ab437bb8-fef8-4b49-b1cf-7724d542c53e",
        "lastSync": "2024-06-14T11:07:06.890994+05:30",
        "numChunks": 4,
        "numDocuments": 4,
        "numErrors": 0,
        "syncing": false,
        "type": "gmail",
        "user": "verbis.ai.test@gmail.com"
      },
      "vectorWeights": null
    }
  ],
  "totalResults": 2
}```